### PR TITLE
Qubino flush 1 relay and dimmer fixes

### DIFF
--- a/Drivers/momentary-button-child-device.src/momentary-button-child-device.groovy
+++ b/Drivers/momentary-button-child-device.src/momentary-button-child-device.groovy
@@ -1,0 +1,42 @@
+/**
+ *  Momentary Button Child Device
+ *
+ *  Copyright 2017 Eric Maycock
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License. You may obtain a copy of the License at:
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software distributed under the License is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
+ *  for the specific language governing permissions and limitations under the License.
+ *
+ */
+metadata {
+	definition (name: "Momentary Button Child Device", namespace: "erocm123", author: "Ben Deitch") {
+        capability "Actuator"
+		capability "Momentary"
+		capability "PushableButton"
+        capability "ReleasableButton"
+		capability "Sensor"
+	}
+}
+
+def installed() {
+	sendEvent(name: "numberOfButtons", value: 1)
+}
+
+def push() {
+    sendEvent(name: "pushed", value: 1, isStateChange: true)
+    state.pushed = true
+}
+
+def release() {
+    if (!state.pushed) {
+    	// sometimes we get a released event from the Qubino without the pushed event
+        sendEvent(name: "pushed", value: 1, isStateChange: true)
+    }
+    sendEvent(name: "released", value: 1, isStateChange: true)
+    state.pushed = false
+}

--- a/Drivers/momentary-button-child-device.src/momentary-button-child-device.groovy
+++ b/Drivers/momentary-button-child-device.src/momentary-button-child-device.groovy
@@ -28,8 +28,8 @@ def installed() {
 }
 
 def push() {
-    sendEvent(name: "pushed", value: 1, isStateChange: true)
     state.pushed = true
+    sendEvent(name: "pushed", value: 1, isStateChange: true)
 }
 
 def release() {

--- a/Drivers/qubino-flush-1-relay.src/qubino-flush-1-relay.groovy
+++ b/Drivers/qubino-flush-1-relay.src/qubino-flush-1-relay.groovy
@@ -326,12 +326,12 @@ def updated()
 	}
     if (childDevices) {
         def childDevice = childDevices.find{it.deviceNetworkId.endsWith("-i2")}
-        if (childDevice && settings."i2" && settings."i2" != "Disabled"  && childDevice.typeName != settings."i2") {
-            childDevice.setDeviceType(settings."i2")
+        if (childDevice && settings."i2" && childDevice.typeName != settings."i2") {
+            changeChildDeviceType(childDevice, settings."i2", 2)
         }
         childDevice = childDevices.find{it.deviceNetworkId.endsWith("-i3")}
-        if (childDevice && settings."i3" && settings."i3" != "Disabled" && childDevice.typeName != settings."i3") {   
-            childDevice.setDeviceType(settings."i3")
+        if (childDevice && settings."i3" && childDevice.typeName != settings."i3") {
+            changeChildDeviceType(childDevice, settings."i3", 3)
         }
     }
     def cmds = [] 
@@ -566,6 +566,21 @@ private void createChildDevices() {
 	   }
     } catch (e) {
        runIn(2, "sendAlert")
+    }
+}
+
+private void changeChildDeviceType(childDevice, deviceType, i) {
+
+    log.debug "Changing ${childDevice} to ${deviceType}"
+    deleteChildDevice(childDevice.deviceNetworkId)
+    if (deviceType != "Disabled") {
+        try {
+            addChildDevice("erocm123", deviceType, "${childDevice.deviceNetworkId}", 
+                [completedSetup: true, label: "${childDevice.displayName}",
+                isComponent: true, componentName: "i$i", componentLabel: "Input $i"])
+        } catch (e) {
+            runIn(2, "sendAlert")
+        }
     }
 }
 

--- a/Drivers/qubino-flush-1-relay.src/qubino-flush-1-relay.groovy
+++ b/Drivers/qubino-flush-1-relay.src/qubino-flush-1-relay.groovy
@@ -40,7 +40,7 @@ metadata {
         fingerprint deviceId: "0x1001", inClusters: "0x5E,0x86,0x72,0x5A,0x73,0x20,0x27,0x25,0x32,0x85,0x8E,0x59,0x70", outClusters: "0x20"
         fingerprint deviceId: "0x1001", inClusters: "0x5E,0x86,0x72,0x5A,0x73,0x20,0x27,0x25,0x32,0x31,0x60,0x85,0x8E,0x59,0x70", outClusters: "0x20" // With temp sensor
 	}
-    
+
     preferences {
         input description: "Once you change values on this page, the corner of the \"configuration\" icon will change orange until all configuration parameters are updated.", title: "Settings", displayDuringSetup: false, type: "paragraph", element: "paragraph"
 		generate_preferences(configuration_model())  
@@ -145,7 +145,7 @@ def zwaveEvent(hubitat.zwave.commands.notificationv3.NotificationReport cmd) {
     logging("NotificationReport: $cmd", 2)
     def result
 
-	if (cmd.notificationType == 2 || cmd.notificationType == 3) {
+    if (cmd.notificationType == 2 || cmd.notificationType == 3) {
     def children = childDevices
 	def childDevice = children.find{it.deviceNetworkId.endsWith("-i2")}
 		switch (cmd.event) {
@@ -170,6 +170,9 @@ def zwaveEvent(hubitat.zwave.commands.notificationv3.NotificationReport cmd) {
                     case "Contact Sensor Child Device":
                         childDevice.sendEvent(name: "contact", value: "open")
                     break
+                    case "Momentary Button Child Device":
+                        childDevice.push()
+                    break
                 }
 			break
 			case 2:
@@ -192,6 +195,9 @@ def zwaveEvent(hubitat.zwave.commands.notificationv3.NotificationReport cmd) {
                     break
                     case "Contact Sensor Child Device":
                         childDevice.sendEvent(name: "contact", value: "closed")
+                    break
+                    case "Momentary Button Child Device":
+                        childDevice.release()
                     break
                 }
 			break
@@ -222,6 +228,9 @@ def zwaveEvent(hubitat.zwave.commands.notificationv3.NotificationReport cmd) {
                     case "Contact Sensor Child Device":
                         childDevice.sendEvent(name: "contact", value: "open")
                     break
+                    case "Momentary Button Child Device":
+                        childDevice.push()
+                    break
                 }
 			break
 			case 2:
@@ -244,6 +253,9 @@ def zwaveEvent(hubitat.zwave.commands.notificationv3.NotificationReport cmd) {
                     break
                     case "Contact Sensor Child Device":
                         childDevice.sendEvent(name: "contact", value: "closed")
+                    break
+                    case "Momentary Button Child Device":
+                        childDevice.release()
                     break
                 }
 			break
@@ -683,7 +695,7 @@ Default: 0 (When system is turned off the output is 0V (NC))
 </Value>
 <Value type="list" byteSize="1" index="100" label="Enable / Disable Endpoint I2 or select Notification Type and Event" min="0" max="9" value="2" setting_type="zwave" fw="" hidden="true">
  <Help>
-Range: 0 to 6, 9
+Range: 0 to 7, 9
 Default: Home Security; Motion Detection, unknown location
 </Help>
         <Item label="Disabled" value="0" />
@@ -693,11 +705,12 @@ Default: Home Security; Motion Detection, unknown location
         <Item label="Water Alarm; Water Leak detected" value="4" />
         <Item label="Heat Alarm; Overheat detected" value="5" />
         <Item label="Smoke Alarm; Smoke detected" value="6" />
+        <Item label="Momentary Button; Button pushed" value="7" />
         <Item label="Sensor Binary" value="9" />
 </Value>
 <Value type="list" byteSize="1" index="101" label="Enable / Disable Endpoint I3 or select Notification Type and Event" min="0" max="9" value="4" setting_type="zwave" fw="" hidden="true">
  <Help>
-Range: 0 to 6, 9
+Range: 0 to 7, 9
 Default: Home Security; Motion Detection, unknown location
 </Help>
         <Item label="Disabled" value="0" />
@@ -707,11 +720,12 @@ Default: Home Security; Motion Detection, unknown location
         <Item label="Water Alarm; Water Leak detected" value="4" />
         <Item label="Heat Alarm; Overheat detected" value="5" />
         <Item label="Smoke Alarm; Smoke detected" value="6" />
+        <Item label="Momentary Button; Button pushed" value="7" />
         <Item label="Sensor Binary" value="9" />
 </Value>
 <Value type="list" byteSize="1" index="i2" label="Enable / Disable Endpoint I2 or select Notification Type and Event" min="0" max="9" value="Contact Sensor Child Device" setting_type="preference" fw="">
  <Help>
-Range: 0 to 6, 9
+Range: 0 to 7, 9
 Default: Home Security; Motion Detection, unknown location
 </Help>
         <Item label="Disabled" value="Disabled" />
@@ -720,11 +734,12 @@ Default: Home Security; Motion Detection, unknown location
         <Item label="Carbon Dioxide; Carbon Dioxide detected" value="Carbon Dioxide Detector Child Device" />
         <Item label="Water Alarm; Water Leak detected" value="Water Sensor Child Device" />
         <Item label="Smoke Alarm; Smoke detected" value="Smoke Detector Child Device" />
+        <Item label="Momentary Button; Button pushed" value="Momentary Button Child Device" />
         <Item label="Sensor Binary" value="Contact Sensor Child Device" />
 </Value>
 <Value type="list" byteSize="1" index="i3" label="Enable / Disable Endpoint I3 or select Notification Type and Event" min="0" max="9" value="Contact Sensor Child Device" setting_type="preference" fw="">
  <Help>
-Range: 0 to 6, 9
+Range: 0 to 7, 9
 Default: Home Security; Motion Detection, unknown location
 </Help>
         <Item label="Disabled" value="Disabled" />
@@ -733,6 +748,7 @@ Default: Home Security; Motion Detection, unknown location
         <Item label="Carbon Dioxide; Carbon Dioxide detected" value="Carbon Dioxide Detector Child Device" />
         <Item label="Water Alarm; Water Leak detected" value="Water Sensor Child Device" />
         <Item label="Smoke Alarm; Smoke detected" value="Smoke Detector Child Device" />
+        <Item label="Momentary Button; Button pushed" value="Momentary Button Child Device" />
         <Item label="Sensor Binary" value="Contact Sensor Child Device" />
 </Value>
 <Value type="number" byteSize="2" index="110" label="Temperature sensor offset settings" min="-100" max="100" value="0" setting_type="zwave" fw="">

--- a/Drivers/qubino-flush-1-relay.src/qubino-flush-1-relay.groovy
+++ b/Drivers/qubino-flush-1-relay.src/qubino-flush-1-relay.groovy
@@ -37,61 +37,14 @@ metadata {
         command "reset"
 
         fingerprint mfr: "0159", prod: "0002", model: "0052"
-	fingerprint deviceId: "0x1001", inClusters: "0x5E,0x86,0x72,0x5A,0x73,0x20,0x27,0x25,0x32,0x85,0x8E,0x59,0x70", outClusters: "0x20"
+        fingerprint deviceId: "0x1001", inClusters: "0x5E,0x86,0x72,0x5A,0x73,0x20,0x27,0x25,0x32,0x85,0x8E,0x59,0x70", outClusters: "0x20"
         fingerprint deviceId: "0x1001", inClusters: "0x5E,0x86,0x72,0x5A,0x73,0x20,0x27,0x25,0x32,0x31,0x60,0x85,0x8E,0x59,0x70", outClusters: "0x20" // With temp sensor
-	}
-
-	simulator {
 	}
     
     preferences {
         input description: "Once you change values on this page, the corner of the \"configuration\" icon will change orange until all configuration parameters are updated.", title: "Settings", displayDuringSetup: false, type: "paragraph", element: "paragraph"
 		generate_preferences(configuration_model())  
     }
-
-	tiles{
-        multiAttributeTile(name:"switch", type: "lighting", width: 6, height: 4, canChangeIcon: true){
-			tileAttribute ("device.switch", key: "PRIMARY_CONTROL") {
-			   attributeState "off", label:'${name}', action:"switch.on", icon:"st.switches.switch.off", backgroundColor:"#ffffff", nextState:"turningOn"
-			   attributeState "on", label:'${name}', action:"switch.off", icon:"st.switches.switch.on", backgroundColor:"#00a0dc", nextState:"turningOff"
-			   attributeState "turningOff", label:'${name}', action:"switch.on", icon:"st.switches.switch.off", backgroundColor:"#ffffff", nextState:"turningOn"
-			   attributeState "turningOn", label:'${name}', action:"switch.off", icon:"st.switches.switch.on", backgroundColor:"#00a0dc", nextState:"turningOff"
-			}
-            tileAttribute ("statusText", key: "SECONDARY_CONTROL") {
-           		attributeState "statusText", label:'${currentValue}'       		
-            }
-	    }
-
-        valueTile("power", "device.power", decoration: "flat", width: 2, height: 2) {
-			state "default", label:'${currentValue} W'
-		}
-		standardTile("energy", "device.energy", decoration: "flat", width: 2, height: 2) {
-			state "default", label:'${currentValue} kWh'
-		}
-        valueTile("temperature", "device.temperature", inactiveLabel: false, width: 2, height: 2) {
-            state "temperature", label:'${currentValue}°',
-            backgroundColors:
-             [
-                [value: 31, color: "#153591"],
-                [value: 44, color: "#1e9cbb"],
-                [value: 59, color: "#90d2a7"],
-				[value: 74, color: "#44b621"],
-				[value: 84, color: "#f1d801"],
-				[value: 95, color: "#d04e00"],
-				[value: 96, color: "#bc2323"]
-			]
-        }
-		standardTile("refresh", "device.switch", inactiveLabel: false, decoration: "flat", width: 2, height: 2) {
-			state "default", label:'', action:"refresh.refresh", icon:"st.secondary.refresh"
-		}
-        standardTile("reset", "device.energy", inactiveLabel: false, decoration: "flat", width: 2, height: 2) {
-		    state "default", label:'reset kWh', action:"reset"
-	    }
-        standardTile("configure", "device.needUpdate", inactiveLabel: false, decoration: "flat", width: 2, height: 2) {
-            state "NO" , label:'', action:"configuration.configure", icon:"st.secondary.configure"
-            state "YES", label:'', action:"configuration.configure", icon:"https://github.com/erocm123/SmartThingsPublic/raw/master/devicetypes/erocm123/qubino-flush-1d-relay.src/configure@2x.png"
-        }
-	}
 }
 
 def installed() {

--- a/Drivers/qubino-flush-1-relay.src/qubino-flush-1-relay.groovy
+++ b/Drivers/qubino-flush-1-relay.src/qubino-flush-1-relay.groovy
@@ -350,7 +350,7 @@ def updated()
     cmds = update_needed_settings()
     sendEvent(name: "checkInterval", value: 2 * 15 * 60 + 2 * 60, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID])
     sendEvent(name:"needUpdate", value: device.currentValue("needUpdate"), displayed:false, isStateChange: true)
-    if (cmds != []) response(commands(cmds))
+    if (cmds != []) commands(cmds)
 }
 
 def generate_preferences(configuration_model)

--- a/Drivers/qubino-flush-dimmer.src/qubino-flush-dimmer.groovy
+++ b/Drivers/qubino-flush-dimmer.src/qubino-flush-dimmer.groovy
@@ -42,60 +42,11 @@ metadata {
         fingerprint deviceId: "0x1101", inClusters: "0x5E,0x86,0x72,0x5A,0x73,0x20,0x27,0x25,0x26,0x30,0x32,0x60,0x85,0x8E,0x59,0x70", outClusters: "0x20,0x26"
         
 	}
-
-	simulator {
-	}
     
     preferences {
         input description: "Once you change values on this page, the corner of the \"configuration\" icon will change orange until all configuration parameters are updated.", title: "Settings", displayDuringSetup: false, type: "paragraph", element: "paragraph"
 		generate_preferences(configuration_model())  
     }
-
-	tiles{
-        multiAttributeTile(name:"switch", type: "lighting", width: 6, height: 4, canChangeIcon: true){
-			tileAttribute ("device.switch", key: "PRIMARY_CONTROL") {
-			   attributeState "off", label:'${name}', action:"switch.on", icon:"st.switches.switch.off", backgroundColor:"#ffffff", nextState:"turningOn"
-			   attributeState "on", label:'${name}', action:"switch.off", icon:"st.switches.switch.on", backgroundColor:"#00a0dc", nextState:"turningOff"
-			   attributeState "turningOff", label:'${name}', action:"switch.on", icon:"st.switches.switch.off", backgroundColor:"#ffffff", nextState:"turningOn"
-			   attributeState "turningOn", label:'${name}', action:"switch.off", icon:"st.switches.switch.on", backgroundColor:"#00a0dc", nextState:"turningOff"
-			}
-            tileAttribute ("device.level", key: "SLIDER_CONTROL") {
-				attributeState "level", action:"switch level.setLevel"
-			}
-            tileAttribute ("statusText", key: "SECONDARY_CONTROL") {
-           		attributeState "statusText", label:'${currentValue}'       		
-            }
-	    }
-        valueTile("power", "device.power", decoration: "flat", width: 2, height: 2) {
-			state "default", label:'${currentValue} W'
-		}
-		standardTile("energy", "device.energy", decoration: "flat", width: 2, height: 2) {
-			state "default", label:'${currentValue} kWh'
-		}
-        valueTile("temperature", "device.temperature", inactiveLabel: false, width: 2, height: 2) {
-            state "temperature", label:'${currentValue}°',
-            backgroundColors:
-             [
-                [value: 31, color: "#153591"],
-                [value: 44, color: "#1e9cbb"],
-                [value: 59, color: "#90d2a7"],
-				[value: 74, color: "#44b621"],
-				[value: 84, color: "#f1d801"],
-				[value: 95, color: "#d04e00"],
-				[value: 96, color: "#bc2323"]
-			]
-        }
-		standardTile("refresh", "device.switch", inactiveLabel: false, decoration: "flat", width: 2, height: 2) {
-			state "default", label:'', action:"refresh.refresh", icon:"st.secondary.refresh"
-		}
-        standardTile("reset", "device.energy", inactiveLabel: false, decoration: "flat", width: 2, height: 2) {
-		    state "default", label:'reset kWh', action:"reset"
-	    }
-        standardTile("configure", "device.needUpdate", inactiveLabel: false, decoration: "flat", width: 2, height: 2) {
-            state "NO" , label:'', action:"configuration.configure", icon:"st.secondary.configure"
-            state "YES", label:'', action:"configuration.configure", icon:"https://github.com/erocm123/SmartThingsPublic/raw/master/devicetypes/erocm123/qubino-flush-1d-relay.src/configure@2x.png"
-        }
-	}
 }
 
 def installed() {

--- a/Drivers/qubino-flush-dimmer.src/qubino-flush-dimmer.groovy
+++ b/Drivers/qubino-flush-dimmer.src/qubino-flush-dimmer.groovy
@@ -313,7 +313,7 @@ def setLevel(level, duration=null) {
     if(level < 1) level = 1
     int delay = duration ? BigDecimal.valueOf(duration).intValueExact() * 1000 : 1000
 	delayBetween([
-		zwave.switchMultilevelV3.switchMultilevelSet(value: level, dimmingDuration: duration).format(),
+		zwave.switchMultilevelV3.switchMultilevelSet(value: level, dimmingDuration: duration ?: 0).format(),
 		zwave.switchMultilevelV1.switchMultilevelGet().format()
 	], delay)
 }

--- a/Drivers/qubino-flush-dimmer.src/qubino-flush-dimmer.groovy
+++ b/Drivers/qubino-flush-dimmer.src/qubino-flush-dimmer.groovy
@@ -59,7 +59,7 @@ def parse(String description) {
 	def result = []
     if (description != "updated") {
 	   logging("description: $description", 1)
-	   def cmd = zwave.parse(description, [0x20: 1, 0x70: 1])
+	   def cmd = zwave.parse(description, [0x20: 1, 0x70: 1, 0x71: 3])
 	   if (cmd) {
 		   result += zwaveEvent(cmd)
 	   }
@@ -282,41 +282,42 @@ def zwaveEvent(hubitat.zwave.Command cmd) {
 
 def on() {
     logging("on()", 1)
-	commands([
-		zwave.basicV1.basicSet(value: 0xFF),
-		zwave.switchBinaryV1.switchBinaryGet()
-	])
+    delayBetween([
+		zwave.switchMultilevelV3.switchMultilevelSet(value: 0xFF, dimmingDuration: 0x00).format(),
+		zwave.switchMultilevelV1.switchMultilevelGet().format()
+	], 1000)  
 }
 
 def off() {
     logging("off()", 1)
-	commands([
-		zwave.basicV1.basicSet(value: 0x00),
-		zwave.switchBinaryV1.switchBinaryGet()
-	])
+	delayBetween([
+		zwave.switchMultilevelV3.switchMultilevelSet(value: 0x00, dimmingDuration: 0x00).format(),
+		zwave.switchMultilevelV1.switchMultilevelGet().format()
+	], 1000)
 }
 
-def setLevel(level) {
-    logging("setLevel($level)", 1)
+def setLevel(level, duration=null) {
+    logging("setLevel($level, $duration)", 1)
 	if(level > 99) level = 99
     if(level < 1) level = 1
-    commands([
-        zwave.basicV1.basicSet(value: level),
-    ])
+    int delay = duration ? BigDecimal.valueOf(duration).intValueExact() * 1000 : 1000
+	delayBetween([
+		zwave.switchMultilevelV3.switchMultilevelSet(value: level, dimmingDuration: duration).format(),
+		zwave.switchMultilevelV1.switchMultilevelGet().format()
+	], delay)
 }
 
 def poll() {
     logging("poll()", 1)
-	command(zwave.switchBinaryV1.switchBinaryGet())
+	command(zwave.switchMultilevelV1.switchMultilevelGet().format())
 }
 
 def refresh() {
     logging("refresh()", 1)
     commands([
-		zwave.switchBinaryV1.switchBinaryGet(),
+		zwave.switchMultilevelV1.switchMultilevelGet().format(),
 		zwave.meterV2.meterGet(scale: 0),
 		zwave.meterV2.meterGet(scale: 2),
-        zwave.sensorMultilevelV5.sensorMultilevelGet(sensorType:1, scale:1)
 	])
 }
 

--- a/Drivers/qubino-flush-dimmer.src/qubino-flush-dimmer.groovy
+++ b/Drivers/qubino-flush-dimmer.src/qubino-flush-dimmer.groovy
@@ -293,17 +293,17 @@ def zwaveEvent(hubitat.zwave.Command cmd) {
 
 def on() {
     logging("on()", 1)
-    delayBetween([
-		zwave.switchMultilevelV3.switchMultilevelSet(value: 0xFF, dimmingDuration: 0x00).format(),
-		zwave.switchMultilevelV1.switchMultilevelGet().format()
+    commands([
+		zwave.switchMultilevelV3.switchMultilevelSet(value: 0xFF, dimmingDuration: 0x00),
+		zwave.switchMultilevelV1.switchMultilevelGet()
 	], 1000)  
 }
 
 def off() {
     logging("off()", 1)
-	delayBetween([
-		zwave.switchMultilevelV3.switchMultilevelSet(value: 0x00, dimmingDuration: 0x00).format(),
-		zwave.switchMultilevelV1.switchMultilevelGet().format()
+	commands([
+		zwave.switchMultilevelV3.switchMultilevelSet(value: 0x00, dimmingDuration: 0x00),
+		zwave.switchMultilevelV1.switchMultilevelGet()
 	], 1000)
 }
 
@@ -312,21 +312,21 @@ def setLevel(level, duration=null) {
 	if(level > 99) level = 99
     if(level < 1) level = 1
     int delay = duration ? BigDecimal.valueOf(duration).intValueExact() * 1000 : 1000
-	delayBetween([
-		zwave.switchMultilevelV3.switchMultilevelSet(value: level, dimmingDuration: duration ?: 0).format(),
-		zwave.switchMultilevelV1.switchMultilevelGet().format()
+	commands([
+		zwave.switchMultilevelV3.switchMultilevelSet(value: level, dimmingDuration: duration ?: 0),
+		zwave.switchMultilevelV1.switchMultilevelGet()
 	], delay)
 }
 
 def poll() {
     logging("poll()", 1)
-	command(zwave.switchMultilevelV1.switchMultilevelGet().format())
+	command(zwave.switchMultilevelV1.switchMultilevelGet())
 }
 
 def refresh() {
     logging("refresh()", 1)
     commands([
-		zwave.switchMultilevelV1.switchMultilevelGet().format(),
+		zwave.switchMultilevelV1.switchMultilevelGet(),
 		zwave.meterV2.meterGet(scale: 0),
 		zwave.meterV2.meterGet(scale: 2),
 	])

--- a/Drivers/qubino-flush-dimmer.src/qubino-flush-dimmer.groovy
+++ b/Drivers/qubino-flush-dimmer.src/qubino-flush-dimmer.groovy
@@ -379,7 +379,7 @@ def updated()
     cmds = update_needed_settings()
     sendEvent(name: "checkInterval", value: 2 * 15 * 60 + 2 * 60, displayed: false, data: [protocol: "zwave", hubHardwareId: device.hub.hardwareID])
     sendEvent(name:"needUpdate", value: device.currentValue("needUpdate"), displayed:false, isStateChange: true)
-    if (cmds != []) response(commands(cmds))
+    if (cmds != []) commands(cmds)
 }
 
 def generate_preferences(configuration_model)

--- a/Drivers/qubino-flush-dimmer.src/qubino-flush-dimmer.groovy
+++ b/Drivers/qubino-flush-dimmer.src/qubino-flush-dimmer.groovy
@@ -356,12 +356,12 @@ def updated()
 	}
     if (childDevices) {
         def childDevice = childDevices.find{it.deviceNetworkId.endsWith("-i2")}
-        if (childDevice && settings."i2" && settings."i2" != "Disabled"  && childDevice.typeName != settings."i2") {
-            childDevice.setDeviceType(settings."i2")
+        if (childDevice && settings."i2" && childDevice.typeName != settings."i2") {
+            changeChildDeviceType(childDevice, settings."i2", 2)
         }
         childDevice = childDevices.find{it.deviceNetworkId.endsWith("-i3")}
-        if (childDevice && settings."i3" && settings."i3" != "Disabled" && childDevice.typeName != settings."i3") {   
-            childDevice.setDeviceType(settings."i3")
+        if (childDevice && settings."i3" && childDevice.typeName != settings."i3") {   
+            changeChildDeviceType(childDevice, settings."i3", 3)
         }
     }
     def cmds = [] 
@@ -596,6 +596,21 @@ private void createChildDevices() {
 	   }
     } catch (e) {
        runIn(2, "sendAlert")
+    }
+}
+
+private void changeChildDeviceType(childDevice, deviceType, i) {
+
+    log.debug "Changing ${childDevice} to ${deviceType}"
+    deleteChildDevice(childDevice.deviceNetworkId)
+    if (deviceType != "Disabled") {
+        try {
+            addChildDevice("erocm123", deviceType, "${childDevice.deviceNetworkId}", 
+                [completedSetup: true, label: "${childDevice.displayName}",
+                isComponent: true, componentName: "i$i", componentLabel: "Input $i"])
+        } catch (e) {
+            runIn(2, "sendAlert")
+        }
     }
 }
 

--- a/Drivers/qubino-flush-dimmer.src/qubino-flush-dimmer.groovy
+++ b/Drivers/qubino-flush-dimmer.src/qubino-flush-dimmer.groovy
@@ -42,7 +42,7 @@ metadata {
         fingerprint deviceId: "0x1101", inClusters: "0x5E,0x86,0x72,0x5A,0x73,0x20,0x27,0x25,0x26,0x30,0x32,0x60,0x85,0x8E,0x59,0x70", outClusters: "0x20,0x26"
         
 	}
-    
+
     preferences {
         input description: "Once you change values on this page, the corner of the \"configuration\" icon will change orange until all configuration parameters are updated.", title: "Settings", displayDuringSetup: false, type: "paragraph", element: "paragraph"
 		generate_preferences(configuration_model())  
@@ -163,9 +163,8 @@ def zwaveEvent(hubitat.zwave.commands.sensorbinaryv2.SensorBinaryReport cmd) {
 def zwaveEvent(hubitat.zwave.commands.notificationv3.NotificationReport cmd) {
     logging("NotificationReport: $cmd", 2)
     def result
-	
-	
-	if (cmd.notificationType == 2) {
+
+    if (cmd.notificationType == 2) {
     def children = childDevices
 	def childDevice = children.find{it.deviceNetworkId.endsWith("-i2")}
 		switch (cmd.event) {
@@ -190,6 +189,9 @@ def zwaveEvent(hubitat.zwave.commands.notificationv3.NotificationReport cmd) {
                     case "Contact Sensor Child Device":
                         childDevice.sendEvent(name: "contact", value: "open")
                     break
+                    case "Momentary Button Child Device":
+                        childDevice.push()
+                    break
                 }
 			break
 			case 2:
@@ -212,6 +214,9 @@ def zwaveEvent(hubitat.zwave.commands.notificationv3.NotificationReport cmd) {
                     break
                     case "Contact Sensor Child Device":
                         childDevice.sendEvent(name: "contact", value: "closed")
+                    break
+                    case "Momentary Button Child Device":
+                        childDevice.release()
                     break
                 }
 			break
@@ -242,6 +247,9 @@ def zwaveEvent(hubitat.zwave.commands.notificationv3.NotificationReport cmd) {
                     case "Contact Sensor Child Device":
                         childDevice.sendEvent(name: "contact", value: "open")
                     break
+                    case "Momentary Button Child Device":
+                        childDevice.push()
+                    break
                 }
 			break
 			case 2:
@@ -264,6 +272,9 @@ def zwaveEvent(hubitat.zwave.commands.notificationv3.NotificationReport cmd) {
                     break
                     case "Contact Sensor Child Device":
                         childDevice.sendEvent(name: "contact", value: "closed")
+                    break
+                    case "Momentary Button Child Device":
+                        childDevice.release()
                     break
                 }
 			break
@@ -763,7 +774,7 @@ Default: 0 (Dimming duration according to parameter 66)
 </Value>
 <Value type="list" byteSize="1" index="100" label="Enable / Disable Endpoint I2 or select Notification Type and Event" min="0" max="9" value="2" setting_type="zwave" fw="" hidden="true">
  <Help>
-Range: 0 to 6, 9
+Range: 0 to 7, 9
 Default: Home Security; Motion Detection, unknown location
 </Help>
         <Item label="Disabled" value="0" />
@@ -773,11 +784,12 @@ Default: Home Security; Motion Detection, unknown location
         <Item label="Water Alarm; Water Leak detected" value="4" />
         <Item label="Heat Alarm; Overheat detected" value="5" />
         <Item label="Smoke Alarm; Smoke detected" value="6" />
+        <Item label="Momentary Button; Button pushed" value="7" />
         <Item label="Sensor Binary" value="9" />
 </Value>
 <Value type="list" byteSize="1" index="101" label="Enable / Disable Endpoint I3 or select Notification Type and Event" min="0" max="9" value="4" setting_type="zwave" fw="" hidden="true">
  <Help>
-Range: 0 to 6, 9
+Range: 0 to 7, 9
 Default: Home Security; Motion Detection, unknown location
 </Help>
         <Item label="Disabled" value="0" />
@@ -787,11 +799,12 @@ Default: Home Security; Motion Detection, unknown location
         <Item label="Water Alarm; Water Leak detected" value="4" />
         <Item label="Heat Alarm; Overheat detected" value="5" />
         <Item label="Smoke Alarm; Smoke detected" value="6" />
+        <Item label="Momentary Button; Button pushed" value="7" />
         <Item label="Sensor Binary" value="9" />
 </Value>
 <Value type="list" byteSize="1" index="i2" label="Enable / Disable Endpoint I2 or select Notification Type and Event" min="0" max="9" value="Contact Sensor Child Device" setting_type="preference" fw="">
  <Help>
-Range: 0 to 6, 9
+Range: 0 to 7, 9
 Default: Home Security; Motion Detection, unknown location
 </Help>
         <Item label="Disabled" value="Disabled" />
@@ -800,11 +813,12 @@ Default: Home Security; Motion Detection, unknown location
         <Item label="Carbon Dioxide; Carbon Dioxide detected" value="Carbon Dioxide Detector Child Device" />
         <Item label="Water Alarm; Water Leak detected" value="Water Sensor Child Device" />
         <Item label="Smoke Alarm; Smoke detected" value="Smoke Detector Child Device" />
+        <Item label="Momentary Button; Button pushed" value="Momentary Button Child Device" />
         <Item label="Sensor Binary" value="Contact Sensor Child Device" />
 </Value>
 <Value type="list" byteSize="1" index="i3" label="Enable / Disable Endpoint I3 or select Notification Type and Event" min="0" max="9" value="Contact Sensor Child Device" setting_type="preference" fw="">
  <Help>
-Range: 0 to 6, 9
+Range: 0 to 7, 9
 Default: Home Security; Motion Detection, unknown location
 </Help>
         <Item label="Disabled" value="Disabled" />
@@ -813,6 +827,7 @@ Default: Home Security; Motion Detection, unknown location
         <Item label="Carbon Dioxide; Carbon Dioxide detected" value="Carbon Dioxide Detector Child Device" />
         <Item label="Water Alarm; Water Leak detected" value="Water Sensor Child Device" />
         <Item label="Smoke Alarm; Smoke detected" value="Smoke Detector Child Device" />
+        <Item label="Momentary Button; Button pushed" value="Momentary Button Child Device" />
         <Item label="Sensor Binary" value="Contact Sensor Child Device" />
 </Value>
 <Value type="number" byteSize="2" index="110" label="Temperature sensor offset settings" min="-100" max="100" value="0" setting_type="zwave" fw="">


### PR DESCRIPTION
Adds the Momentary Button Child Device to the Qubino Flush Dimmer and Qubino Flush 1 Relay.
Fix issue with Hubitat when changing child device types.
Changes the Z-Wave commands used for on/off/setLevel/refresh and poll to improve response time for Qubino Flush Dimmer.
