### PR TITLE
Updated to ensure it is detected as a light by smart home platforms

### DIFF
--- a/Drivers/metering-switch-child-device.src/metering-switch-child-device.groovy
+++ b/Drivers/metering-switch-child-device.src/metering-switch-child-device.groovy
@@ -18,6 +18,8 @@ metadata {
 		capability "Switch"
 		capability "Actuator"
 		capability "Sensor"
+		capability "Bulb"
+		capability "Light"
         capability "Energy Meter"
         capability "Power Meter"
         capability "Refresh"


### PR DESCRIPTION
Without these parameters Google Home and Alexa detect it as a switch, so you cannot say 'Turn off the X light' as it doesnt think it is a light